### PR TITLE
configure: Fix mvme2700 build

### DIFF
--- a/configure/os/CONFIG.Common.RTEMS
+++ b/configure/os/CONFIG.Common.RTEMS
@@ -65,7 +65,7 @@ CXXFLAGS = $($(BUILD_CLASS)_CXXFLAGS) $(POSIX_CXXFLAGS) $(OPT_CXXFLAGS)\
  $(USR_CXXFLAGS) $(CMD_CXXFLAGS) $(ARCH_DEP_CXXFLAGS) $(CODE_CXXFLAGS)\
  $(STATIC_CXXFLAGS) $(OP_SYS_CXXFLAGS) $(LIBRARY_SRC_CFLAGS)
 
-LDFLAGS = $(OPT_LDFLAGS) $(TARGET_LDFLAGS) $(USR_LDFLAGS) $(CMD_LDFLAGS)\
+LDFLAGS += $(OPT_LDFLAGS) $(TARGET_LDFLAGS) $(USR_LDFLAGS) $(CMD_LDFLAGS)\
  $(POSIX_LDFLAGS) $(ARCH_DEP_LDFLAGS) $(DEBUG_LDFLAGS) $(OP_SYS_LDFLAGS)\
  $($(BUILD_CLASS)_LDFLAGS) $(RUNTIME_LDFLAGS) $(CODE_LDFLAGS)
 
@@ -102,17 +102,38 @@ OS_CLASS = RTEMS
 # Operating system compile & link flags
 OP_SYS_CFLAGS += -D__LINUX_ERRNO_EXTENSIONS__
 
-OP_SYS_CFLAGS_NET_yes = -DRTEMS_LEGACY_STACK
-OP_SYS_CFLAGS += $(OP_SYS_CFLAGS_NET_$(RTEMS_HAS_NETWORKING))
+# Has RTEMS been built with the legacy stack as a separate package?
+ifeq ($(RTEMS_LEGACY_NETWORKING),yes)
+RTEMS_HAS_NETWORKING = yes
+RTEMS_NETWORKING = legacy
+endif
+
+# Has RTEMS been built with the libbsd stack as a separate package?
+ifeq ($(RTEMS_BSD_NETWORKING),yes)
+RTEMS_HAS_NETWORKING = yes
+RTEMS_NETWORKING = bsd
+endif
+
+RTEMS_LEGACY_NET_LIB_no=
+
+# Leagcy network with RTEMS 6 is a separate package and library
+RTEMS_NET_LIB_legacy=-lnfs -lnetworking -lnfs
+OP_SYS_CFLAGS_NET_legacy = -DRTEMS_LEGACY_STACK
+
+# LibBSD network with RTEMS 5 and 6 is a separate package and library
+RTEMS_NET_LIB_bsd=-lbsd
+OP_SYS_CFLAGS_NET_bsd = -DRTEMS_LIBBSD_STACK
+
+# Set the networking flags
+OP_SYS_CFLAGS += $(OP_SYS_CFLAGS_NET_$(RTEMS_NETWORKING))
 
 ifeq ($(RTEMS_HAS_POSIX_API),yes)
 POSIX_CPPFLAGS = -D_GNU_SOURCE -D_DEFAULT_SOURCE
 endif
 
-OP_SYS_LDLIBS_posix_NET_yes = -ltftpfs -lnfs -lz -ltelnetd
-OP_SYS_LDLIBS_posix_NET_no = -ltftpfs -lbsd -lz
-OP_SYS_LDLIBS_score_NET_yes = -lnfs
-OP_SYS_LDLIBS_score_NET_no = -lnfs
+OP_SYS_LDLIBS_posix_NET_yes = -ltftpfs -lz -ltelnetd
+OP_SYS_LDLIBS_posix_NET_yes += $(RTEMS_NET_LIB_$(RTEMS_NETWORKING))
+OP_SYS_LDLIBS_posix_NET_no = -ltftpfs -lz
 OP_SYS_LDLIBS += -lrtemsCom -lCom
 OP_SYS_LDLIBS += $(OP_SYS_LDLIBS_$(OS_API)_NET_$(RTEMS_HAS_NETWORKING))
 OP_SYS_LDLIBS += -lrtemscpu -lc -lm

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -1,11 +1,6 @@
 #
 # Author: Matt Rippa
 #
-ifeq ($(shell test $(RTEMS_VERSION) -gt 5; echo $$?),0)
-RTEMS_BSP = mvme2700
-else
-RTEMS_BSP = mvme2307
-endif
 RTEMS_TARGET_CPU = powerpc
 ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 ARCH_DEP_CFLAGS += -DHAVE_PPCBUG
@@ -27,3 +22,9 @@ define MUNCH_CMD
 endef
 
 include $(CONFIG)/os/CONFIG.Common.RTEMS
+
+ifeq ($(RTEMS_VERSION), $(word 1, $(sort 5 $(RTEMS_VERSION))))
+RTEMS_BSP = mvme2307
+else
+RTEMS_BSP = mvme2700
+endif

--- a/configure/os/CONFIG.Common.RTEMS-mvme2700
+++ b/configure/os/CONFIG.Common.RTEMS-mvme2700
@@ -1,7 +1,11 @@
 #
 # Author: Matt Rippa
 #
+ifeq ($(shell test $(RTEMS_VERSION) -gt 5; echo $$?),0)
+RTEMS_BSP = mvme2700
+else
 RTEMS_BSP = mvme2307
+endif
 RTEMS_TARGET_CPU = powerpc
 ARCH_DEP_CFLAGS += -DMY_DO_BOOTP=NULL
 ARCH_DEP_CFLAGS += -DHAVE_PPCBUG

--- a/configure/toolchain.c
+++ b/configure/toolchain.c
@@ -34,6 +34,23 @@ OS_API = posix
 #  else
 OS_API = score
 #  endif
+#  if defined(RTEMS_NETWORKING)
+     // legacy stack circa RTEMS <= 5 and networking internal to RTEMS
+RTEMS_LEGACY_NETWORKING = yes
+#  else
+#    if !defined(__has_include)
+       // assume old GCC implies RTEMS < 5 with mis-configured BSP
+#      error rebuild BSP with --enable-network
+#    elif __has_include(<machine/rtems-net-legacy.h>)
+       // legacy stack circa RTEMS > 5
+RTEMS_LEGACY_NETWORKING = yes
+#    elif __has_include(<machine/rtems-bsd-version.h>)
+       // libbsd stack
+RTEMS_BSD_NETWORKING = yes
+#    else
+#      error Cannot determine RTEMS network configuration
+#    endif
+#  endif
 #endif
 
 #ifdef __has_include

--- a/modules/libcom/RTEMS/posix/rtems_config.c
+++ b/modules/libcom/RTEMS/posix/rtems_config.c
@@ -2,7 +2,7 @@
 * Copyright (c) 2002 The University of Saskatchewan
 * EPICS BASE Versions 3.13.7
 * and higher are distributed subject to a Software License Agreement found
-* in file LICENSE that is included with this distribution. 
+* in file LICENSE that is included with this distribution.
 \*************************************************************************/
 /*
  * RTEMS configuration for EPICS
@@ -121,16 +121,17 @@ extern void *POSIX_Init(void *argument);
   &rtems_shell_SYSCTL_Command
 #else // LEGACY_STACK:
 #define CONFIGURE_SHELL_USER_COMMANDS \
-  &bsp_interrupt_shell_command, \
-  &rtems_shell_PING_Command, \
-  &rtems_shell_ROUTE_Command, \
-  &rtems_shell_IFCONFIG_Command
-#endif
+  &bsp_interrupt_shell_command
+#endif // not LEGACY_STACK
 
 #define CONFIGURE_SHELL_COMMAND_CPUUSE
 #define CONFIGURE_SHELL_COMMAND_PERIODUSE
 #define CONFIGURE_SHELL_COMMAND_STACKUSE
 #define CONFIGURE_SHELL_COMMAND_PROFREPORT
+#define CONFIGURE_SHELL_COMMAND_TOP
+#define CONFIGURE_SHELL_COMMAND_RTEMS
+
+#define CONFIGURE_SHELL_COMMANDS_ALL_NETWORKING
 
 #define CONFIGURE_SHELL_COMMAND_CP
 #define CONFIGURE_SHELL_COMMAND_PWD
@@ -148,14 +149,15 @@ extern void *POSIX_Init(void *argument);
 #define CONFIGURE_SHELL_COMMAND_SHUTDOWN
 
 #include <rtems/shellconfig.h>
+
 #define RTEMS_BSD_CONFIG_BSP_CONFIG
 #define RTEMS_BSD_CONFIG_SERVICE_TELNETD
 #define RTEMS_BSD_CONFIG_TELNETD_STACK_SIZE (16 * 1024)
 #define RTEMS_BSD_CONFIG_SERVICE_FTPD
 #define RTEMS_BSD_CONFIG_FIREWALL_PF
-#else
+#else // __RTEMS_MAJOR__ > 4
 #include <rtems/shellconfig.h>
-#endif // not LEGACY_STACK
+#endif // __RTEMS_MAJOR__ > 4
 
 #if __RTEMS_MAJOR__ < 5 // still needed in Version 4?
 #define CONFIGURE_MAXIMUM_TASKS             rtems_resource_unlimited(30)

--- a/modules/libcom/RTEMS/posix/rtems_init.c
+++ b/modules/libcom/RTEMS/posix/rtems_init.c
@@ -102,9 +102,9 @@ char bootp_server_name_init[128] = "1001.1001@10.0.5.1:/epics";
 char bootp_boot_file_name_init[128] = "/epics/myExample/bin/RTEMS-beatnik/myExample.boot";
 char bootp_cmdline_init[128] = "/epics/myExample/iocBoot/iocmyExample/st.cmd";
 
-struct in_addr rtems_bsdnet_bootp_server_address;
 /* TODO check rtems_bsdnet_bootp_cmdline */
 #ifndef RTEMS_LEGACY_STACK
+struct in_addr rtems_bsdnet_bootp_server_address;
 char *rtems_bsdnet_bootp_server_name = bootp_server_name_init;
 char *rtems_bsdnet_bootp_boot_file_name = bootp_boot_file_name_init;
 char *rtems_bsdnet_bootp_cmdline = bootp_cmdline_init;


### PR DESCRIPTION
Use `RTEMS_VERSION` set by`CONFIG.Common.RTEMS` and use make functions instead of `test` for Windows compatibility.